### PR TITLE
include quoted comments in rule options

### DIFF
--- a/grammars/nftables.cson
+++ b/grammars/nftables.cson
@@ -475,14 +475,14 @@
                                 'name': 'constant.numeric.countervalue.nft'
                     }]
           }
-          { # comment_stmt
-            'match': '(comment)\\s+(("|\')((?:\\\\["\']|[^"\']|\'[^$])+)("|\'))'
+          { #comment_spec
+            'match': '(comment)\\s+("[^"]+"|[a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*)'
             'name': 'meta.stmt.comment.nft'
             'captures':
                 '1':
-                    'name': 'keyword.modifier.comment.stmt.nft'
+                    'name': 'keyword.other.comment.nft'
                 '2':
-                    'name': 'support.quoted.string.comment.text.nft'
+                    'name': 'support.quoted.string.comment.nft'
           }
           { #log_stmt
             'match': '(log)(?:\\s+(prefix\\s+(?:"[^"]+"|[a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*\\b)|(group|snaplen|queue-threshold)\\s+(\\d+|0[xX][A-Fa-f0-9]+)|level\\s+(?:emerg|alert|crit|err|warn|notice|info|debug)|flags\\s+(all|skuid|ether|ip\\s+options|tcp\\s+(sequence|options|\\s*,\\s*)*))*)'

--- a/grammars/nftables.cson
+++ b/grammars/nftables.cson
@@ -475,6 +475,15 @@
                                 'name': 'constant.numeric.countervalue.nft'
                     }]
           }
+          { # comment_stmt
+            'match': '(comment)\\s+(("|\')((?:\\\\["\']|[^"\']|\'[^$])+)("|\'))'
+            'name': 'meta.stmt.comment.nft'
+            'captures':
+                '1':
+                    'name': 'keyword.modifier.comment.stmt.nft'
+                '2':
+                    'name': 'support.quoted.string.comment.text.nft'
+          }
           { #log_stmt
             'match': '(log)(?:\\s+(prefix\\s+(?:"[^"]+"|[a-zA-Z_\\.][a-zA-Z0-9/\\-_\\.]*\\b)|(group|snaplen|queue-threshold)\\s+(\\d+|0[xX][A-Fa-f0-9]+)|level\\s+(?:emerg|alert|crit|err|warn|notice|info|debug)|flags\\s+(all|skuid|ether|ip\\s+options|tcp\\s+(sequence|options|\\s*,\\s*)*))*)'
             'name': 'meta.stmt.log'


### PR DESCRIPTION
Rule lines allow for `comment "something to display"` this adds support and includes support for internal escaped or apostrophes within those strings.